### PR TITLE
bug in the altitude_fuser.py

### DIFF
--- a/python/altitude_fuser.py
+++ b/python/altitude_fuser.py
@@ -95,7 +95,7 @@ class ASL_EKF(EKF):
         # Sonar response is linear, so derivative is constant
         dsdx = 0.933
 
-        return np.array([[dpdx], [dsdx]])
+        return np.array([dpdx, [dsdx]])
 
 
 class ASL_Plotter(RealtimePlotter):


### PR DESCRIPTION
in the function getH(): dpdx is already an array and shouldn't be converted once again. Without this fix the update procedure of EKF filter will fail due to the type incompatibility:
G = np.dot(self.P_pre * self.H.T, np.linalg.inv(self.H * self.P_pre * self.H.T + self.R))
  File "/usr/lib/python2.7/dist-packages/numpy/linalg/linalg.py", line 526, in inv
    ainv = _umath_linalg.inv(a, signature=signature, extobj=extobj)
TypeError: No loop matching the specified signature and casting
was found for ufunc inv