### PR TITLE
docs: fix simple typo, centimters -> centimeters

### DIFF
--- a/extras/python/altitude_fuser.py
+++ b/extras/python/altitude_fuser.py
@@ -4,7 +4,7 @@ altitude_fuser.py - Sonar / Barometer fusion example using TinyEKF.
 
 We model a single state variable, altitude above sea level (ASL) in centimeters.
 This is obtained by fusing the barometer pressure in Pascals and sonar above-ground level
-(ASL) in centimters.
+(ASL) in centimeters.
 
 Also requires RealtimePlotter: https://github.com/simondlevy/RealtimePlotter
 


### PR DESCRIPTION
There is a small typo in extras/python/altitude_fuser.py.

Should read `centimeters` rather than `centimters`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md